### PR TITLE
fix: add .js extension to ESM output filename

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'ShimmerFromStructure',
       formats: ['es', 'umd'],
-      fileName: (format) => `index.${format === 'es' ? 'esm' : 'js'}`,
+      fileName: (format) => `index.${format === 'es' ? 'esm.js' : 'js'}`,
     },
     rollupOptions: {
       external: ['react', 'react-dom'],


### PR DESCRIPTION
## Summary

- Fixes ESM output filename to include `.js` extension

## Problem

The Vite build config outputs `dist/index.esm` but `package.json` references `dist/index.esm.js`, causing module resolution to fail in Vite 7.x projects:

```
[plugin:vite:import-analysis] Failed to resolve entry for package "shimmer-from-structure". 
The package may have incorrect main/module/exports specified in its package.json.
```

## Solution

Updated `vite.config.ts` to output `index.esm.js` instead of `index.esm`:

```diff
- fileName: (format) => `index.${format === 'es' ? 'esm' : 'js'}`,
+ fileName: (format) => `index.${format === 'es' ? 'esm.js' : 'js'}`,
```

This ensures the built output matches the `module` field in `package.json`.

## Test Plan

1. Run `npm run build`
2. Verify `dist/index.esm.js` exists (not `dist/index.esm`)
3. Install in a Vite 7.x project and confirm import works