### PR TITLE
fix:style of header in examples has been changed to sticky

### DIFF
--- a/examples/react-example/src/main.css
+++ b/examples/react-example/src/main.css
@@ -40,11 +40,14 @@ body {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 32px;
-  padding: 24px 32px;
+  padding: 20px 32px;
   background: rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(10px);
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.1);
+  position: sticky;
+  top: 15px;
+  z-index: 50;
 }
 
 .header-content h1 {

--- a/examples/svelte-example/src/main.css
+++ b/examples/svelte-example/src/main.css
@@ -40,11 +40,14 @@ body {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 32px;
-  padding: 24px 32px;
+  padding: 20px 32px;
   background: rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(10px);
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.1);
+  position: sticky;
+  top: 15px;
+  z-index: 50;
 }
 
 .header-content h1 {

--- a/examples/vue-example/src/style.css
+++ b/examples/vue-example/src/style.css
@@ -40,11 +40,14 @@ body {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 32px;
-  padding: 24px 32px;
+  padding: 20px 32px;
   background: rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(10px);
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.1);
+  position: sticky;
+  top: 15px;
+  z-index: 50;
 }
 
 .header-content h1 {


### PR DESCRIPTION
### **What does this PR do?**
In the example sections for **React**, **Vue**, and **Svelte**, the header was previously a scrollable element. I have updated these headers to be `sticky`. This change ensures that the header remains visible, allowing users to see the loading effects more clearly in the bottom-most components while scrolling.

### **Changes Made**
* **React Example:** Updated `src/main.css` to implement sticky header logic.
* **Vue Example:** Updated `src/style.css` for consistent sticky behavior.
* **Svelte Example:** Updated `src/main.css` to match the new styling.

### **Testing**
* Verified the build passes for Core, React, Vue, and Svelte packages.
* Manually verified the "sticky" behavior in the browser across all three example projects.

Closes #9

Hey @darula-hpp, I've updated the headers to be sticky as discussed. Could you please take a look?
