### PR TITLE
quick grammar improvement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Shimmer From Structure provides dedicated packages for **React and Vue**.
 
 ### React
 
-React support is built-in to the main package for backward compatibility:
+React support is built into the main package for backward compatibility:
 
 ```javascript
 // React projects (or @shimmer-from-structure/react)


### PR DESCRIPTION
"built-in" (with hyphen) is used when the two words together form a single adjective, such as in "built-in support", but the hyphen is not needed in a phrase like "support is built in".

"In" and "to" are not really functioning as separate words, so the single preposition "into" makes more sense here.