### PR TITLE
bug: fix issues where br tag wasnt shimmered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2026-02-21
+
+### Fixed
+
+- **Core: `<br>` Tag Handling in `isLeafElement`**: Elements containing both text and `<br />` tags (e.g. `<p>First line.<br />Second line.</p>`) are now correctly shimmered.
+  - Previously, the presence of a `<br>` child caused the parent element to be skipped as a shimmer candidate, leaving it blank during the loading state.
+  - `isLeafElement` now ignores void/formatting elements (`br`, `wbr`, `hr`) when deciding whether an element has real children, treating such containers as leaf content blocks.
+  - The workaround of wrapping text in `<span className="block">` or removing `<br>` tags is no longer required.
+
 ## [2.3.1] - 2026-02-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shimmer-from-structure",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "private": true,
   "description": "Universal UI skeleton generator for React, Vue, Svelte, Angular and SolidJS. Auto-adapts to your component structure with zero maintenance and pixel-perfect accuracy.",
   "workspaces": [

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shimmer-from-structure/angular",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Angular adapter for shimmer-from-structure",
   "peerDependencies": {
     "@angular/common": "^19.0.0 || ^20.0.0 || ^21.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shimmer-from-structure/core",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Framework-agnostic DOM measurement utilities for shimmer effects",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -23,6 +23,27 @@ describe('isLeafElement', () => {
     div.appendChild(span);
     expect(isLeafElement(div)).toBe(false);
   });
+
+  it('returns true for elements whose only element children are <br> tags', () => {
+    const p = document.createElement('p');
+    p.appendChild(document.createTextNode('First line.'));
+    p.appendChild(document.createElement('br'));
+    p.appendChild(document.createTextNode('Second line.'));
+    expect(isLeafElement(p)).toBe(true);
+  });
+
+  it('returns true for elements with only <br> children and no text', () => {
+    const div = document.createElement('div');
+    div.appendChild(document.createElement('br'));
+    expect(isLeafElement(div)).toBe(true);
+  });
+
+  it('returns false for elements with <br> AND real element children', () => {
+    const div = document.createElement('div');
+    div.appendChild(document.createElement('br'));
+    div.appendChild(document.createElement('span'));
+    expect(isLeafElement(div)).toBe(false);
+  });
 });
 
 describe('extractElementInfo', () => {

--- a/packages/core/src/isLeafElement.ts
+++ b/packages/core/src/isLeafElement.ts
@@ -10,10 +10,14 @@ export function isLeafElement(element: Element): boolean {
     return true;
   }
 
-  // Check if element has no element children (only text nodes or no children)
-  const hasElementChildren = Array.from(element.children).length > 0;
-  if (!hasElementChildren) {
-    // This is a leaf element (contains only text or is empty)
+  // Check if element has no *real* element children (ignore void/formatting
+  // elements like <br> that carry no dimensions of their own)
+  const voidElements = ['br', 'wbr', 'hr'];
+  const hasRealChildren = Array.from(element.children).some(
+    (child) => !voidElements.includes(child.tagName.toLowerCase())
+  );
+  if (!hasRealChildren) {
+    // Treat as a leaf element: contains only text and/or void elements
     return true;
   }
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shimmer-from-structure/react",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "React adapter for shimmer-from-structure",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/shimmer-from-structure/package.json
+++ b/packages/shimmer-from-structure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shimmer-from-structure",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Universal UI skeleton generator for React, Vue and Svelte. Auto-adapts to your component structure with zero maintenance and pixel-perfect accuracy.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shimmer-from-structure/solid",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "SolidJS adapter for shimmer-from-structure",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shimmer-from-structure/svelte",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "type": "module",
   "description": "Svelte adapter for shimmer-from-structure",
   "main": "dist/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shimmer-from-structure/vue",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Vue 3 adapter for shimmer-from-structure",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
### Fixed

- **Core: `<br>` Tag Handling in `isLeafElement`**: Elements containing both text and `<br />` tags (e.g. `<p>First line.<br />Second line.</p>`) are now correctly shimmered.
  - Previously, the presence of a `<br>` child caused the parent element to be skipped as a shimmer candidate, leaving it blank during the loading state.
  - `isLeafElement` now ignores void/formatting elements (`br`, `wbr`, `hr`) when deciding whether an element has real children, treating such containers as leaf content blocks.
  - The workaround of wrapping text in `<span className="block">` or removing `<br>` tags is no longer required.