### PR TITLE
Fix: React 18 Production Crash (#44)

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shimmer-from-structure/react",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "React adapter for shimmer-from-structure",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -24,6 +24,12 @@
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "dependencies": {
     "@shimmer-from-structure/core": "*"

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -20,11 +20,18 @@ export default defineConfig({
       fileName: (format: string) => `index.${format === 'es' ? 'esm.js' : 'js'}`,
     },
     rollupOptions: {
-      external: ['react', 'react-dom', '@shimmer-from-structure/core'],
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+        '@shimmer-from-structure/core',
+      ],
       output: {
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
+          'react/jsx-runtime': 'jsxRuntime',
           '@shimmer-from-structure/core': 'ShimmerCore',
         },
       },


### PR DESCRIPTION
This PR fixes the 'Objects are not valid as a React child' error in production.

### Changes
- Externalized `react/jsx-runtime` and `react/jsx-dev-runtime` in Vite config.
- Pinned React package development to React 18.2.0.
- Bumped version to 2.3.3.

This prevents React 19's transitional elements from being bundled, which caused the crash in React 18 environments.