### PR TITLE
Fix : Upgrade svelte version in the svelte adapter

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -24,7 +24,7 @@
     "prepublishOnly": "cp ../../README.md ."
   },
   "peerDependencies": {
-    "svelte": "^5.0.0"
+    "svelte": "^5.53.5"
   },
   "dependencies": {
     "@shimmer-from-structure/core": "*"
@@ -35,7 +35,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.3.1",
     "jsdom": "^27.4.0",
-    "svelte": "^5.0.0",
+    "svelte": "^5.53.5",
     "svelte-check": "^4.0.0",
     "tslib": "^2.0.0",
     "typescript": "^5.0.0",


### PR DESCRIPTION
fix(security): update Svelte to 5.53.5 to patch vulnerabilities

Update Svelte peer and dev dependencies from ^5.0.0 to ^5.53.5 to address:
- CVE-2026-27125: Prototype pollution in SSR attribute spreading
- CVE-2026-27902: XSS/HTML injection from unescaped transformError
- CVE-2025-15265: XSS via hydratable components